### PR TITLE
Set specific versions/builds to update sites

### DIFF
--- a/es.unizar.disco.simulation.targetplatform/sdk.target
+++ b/es.unizar.disco.simulation.targetplatform/sdk.target
@@ -10,7 +10,7 @@
 <unit id="org.eclipse.papyrus.extra.marte.feature.source.feature.group" version="1.2.0.201606080903"/>
 <unit id="org.eclipse.papyrus.extra.marte.feature.feature.group" version="1.2.0.201606080903"/>
 <unit id="org.eclipse.papyrus.extra.marte.textedit.feature.feature.group" version="1.2.0.201606080903"/>
-<repository location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/neon"/>
+<repository location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/neon/2.0.0/"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="fr.lip6.pnml.framework.sdk.feature.group" version="2.2.12"/>
@@ -29,7 +29,7 @@
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.6.0.I20160606-1100"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.6"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6/R-4.6-201606061100/"/>
 </location>
 <location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>


### PR DESCRIPTION
Set specific versions for the Update Sites of the Eclipse Platform and Papyrus, which are no longer valid after the release of Eclipse 4.6.1.

Fixes issue 5.