### PR TITLE
DTSM - Changes in PNextensions and Spark transformations

### DIFF
--- a/bundles/es.unizar.disco.pnextensions/model/pnextensions.ecore
+++ b/bundles/es.unizar.disco.pnextensions/model/pnextensions.ecore
@@ -14,6 +14,7 @@
       <eLiterals name="Exponential" value="1" literal="http://es.unizar.disco/pnconstants/tkind/exponential"/>
       <eLiterals name="Deterministic" value="2" literal="http://es.unizar.disco/pnconstants/tkind/deterministic"/>
       <eLiterals name="ImmediatePriority" value="3" literal="http://es.unizar.disco/pnconstants/tkind/immediatepriority"/>
+      <eLiterals name="Erlang" value="4" literal="Erlang"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EEnum" name="ServerType">
       <eLiterals name="InfiniteServer" literal="http://es.unizar.dsico/pnconstants/tserv/infinite"/>

--- a/bundles/es.unizar.disco.pnextensions/model/pnextensions.ecore
+++ b/bundles/es.unizar.disco.pnextensions/model/pnextensions.ecore
@@ -14,7 +14,7 @@
       <eLiterals name="Exponential" value="1" literal="http://es.unizar.disco/pnconstants/tkind/exponential"/>
       <eLiterals name="Deterministic" value="2" literal="http://es.unizar.disco/pnconstants/tkind/deterministic"/>
       <eLiterals name="ImmediatePriority" value="3" literal="http://es.unizar.disco/pnconstants/tkind/immediatepriority"/>
-      <eLiterals name="Erlang" value="4" literal="Erlang"/>
+      <eLiterals name="Erlang" value="4" literal="http://es.unizar.disco/pnconstants/tkind/erlang"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EEnum" name="ServerType">
       <eLiterals name="InfiniteServer" literal="http://es.unizar.dsico/pnconstants/tserv/infinite"/>

--- a/bundles/es.unizar.disco.pnextensions/model/pnextensions.genmodel
+++ b/bundles/es.unizar.disco.pnextensions/model/pnextensions.genmodel
@@ -8,7 +8,8 @@
   <foreignModel>pnextensions.ecore</foreignModel>
   <genPackages prefix="Pnextensions" basePackage="es.unizar.disco" disposableProviderFactory="true"
       ecorePackage="pnextensions.ecore#/">
-    <nestedGenPackages prefix="Pnconstants" disposableProviderFactory="true" ecorePackage="pnextensions.ecore#//pnconstants">
+    <nestedGenPackages prefix="Pnconstants" basePackage="es.unizar.disco.pnextensions"
+        disposableProviderFactory="true" ecorePackage="pnextensions.ecore#//pnconstants">
       <genEnums typeSafeEnumCompatible="false" ecoreEnum="pnextensions.ecore#//pnconstants/ToolInfoConstants">
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ToolInfoConstants/toolName"/>
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ToolInfoConstants/toolVersion"/>
@@ -18,6 +19,8 @@
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/TransitionKind/Immediate"/>
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/TransitionKind/Exponential"/>
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/TransitionKind/Deterministic"/>
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/TransitionKind/ImmediatePriority"/>
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/TransitionKind/Erlang"/>
       </genEnums>
       <genEnums typeSafeEnumCompatible="false" ecoreEnum="pnextensions.ecore#//pnconstants/ServerType">
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ServerType/InfiniteServer"/>
@@ -25,12 +28,24 @@
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ServerType/LoadDependent"/>
         <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ServerType/MarkingDependent"/>
       </genEnums>
+      <genEnums typeSafeEnumCompatible="false" ecoreEnum="pnextensions.ecore#//pnconstants/BaseUnitsConstants">
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/BaseUnitsConstants/baseTimeUnit"/>
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/BaseUnitsConstants/baseFrequencyUnit"/>
+      </genEnums>
+      <genEnums typeSafeEnumCompatible="false" ecoreEnum="pnextensions.ecore#//pnconstants/Color">
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/Color/Color"/>
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/Color/ColorSet"/>
+      </genEnums>
+      <genEnums typeSafeEnumCompatible="false" ecoreEnum="pnextensions.ecore#//pnconstants/ArcKind">
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ArcKind/Normal"/>
+        <genEnumLiterals ecoreEnumLiteral="pnextensions.ecore#//pnconstants/ArcKind/Inhibitor"/>
+      </genEnums>
     </nestedGenPackages>
-    <nestedGenPackages prefix="Pnutils" disposableProviderFactory="true" ecorePackage="pnextensions.ecore#//pnutils">
+    <nestedGenPackages prefix="Pnutils" basePackage="es.unizar.disco.pnextensions"
+        disposableProviderFactory="true" ecorePackage="pnextensions.ecore#//pnutils">
       <genDataTypes ecoreDataType="pnextensions.ecore#//pnutils/URI"/>
       <genDataTypes ecoreDataType="pnextensions.ecore#//pnutils/URISyntaxException"/>
       <genDataTypes ecoreDataType="pnextensions.ecore#//pnutils/StringBuffer"/>
-      <genDataTypes ecoreDataType="pnextensions.ecore#//pnutils/IllegalArgumentException"/>
       <genClasses ecoreClass="pnextensions.ecore#//pnutils/PnUtils">
         <genOperations ecoreOperation="pnextensions.ecore#//pnutils/PnUtils/layout">
           <genParameters ecoreParameter="pnextensions.ecore#//pnutils/PnUtils/layout/petriNet"/>
@@ -42,48 +57,6 @@
         </genOperations>
         <genOperations ecoreOperation="pnextensions.ecore#//pnutils/DataTypeUtils/createLongString">
           <genParameters ecoreParameter="pnextensions.ecore#//pnutils/DataTypeUtils/createLongString/string"/>
-        </genOperations>
-      </genClasses>
-      <genClasses ecoreClass="pnextensions.ecore#//pnutils/ToolInfoUtils">
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/isEObjectValidPnObject">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isEObjectValidPnObject/eObject"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/isEObjectValidTransition">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isEObjectValidTransition/eObject"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/getToolInfoEntryByGrammarUri">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/getToolInfoEntryByGrammarUri/pnObject"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/getToolInfoEntryByGrammarUri/uri"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/deleteToolInfoEntryByGrammarUri">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/deleteToolInfoEntryByGrammarUri/pnObject"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/deleteToolInfoEntryByGrammarUri/uri"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/setToolInfoEntryByGrammarUri">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setToolInfoEntryByGrammarUri/pnObject"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setToolInfoEntryByGrammarUri/uri"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setToolInfoEntryByGrammarUri/value"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionKind">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionKind/transition"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionKind/transitionKind"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionServerType">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionServerType/transition"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/isTransitionServerType/serverType"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionKind">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionKind/transition"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionKind/transitionKind"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionKind/value"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionServerType">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionServerType/transition"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionServerType/serverType"/>
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/setTransitionServerType/value"/>
-        </genOperations>
-        <genOperations ecoreOperation="pnextensions.ecore#//pnutils/ToolInfoUtils/getTransitionRate">
-          <genParameters ecoreParameter="pnextensions.ecore#//pnutils/ToolInfoUtils/getTransitionRate/transition"/>
         </genOperations>
       </genClasses>
     </nestedGenPackages>

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/ArcKind.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/ArcKind.java
@@ -26,7 +26,7 @@ public enum ArcKind implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	NORMAL(0, "Normal", "http://es.unizar.dsico/pnconstants/akind/normal"),
+	NORMAL(0, "Normal", "http://es.unizar.dsico/pnconstants/tkind/immediate"),
 
 	/**
 	 * The '<em><b>Inhibitor</b></em>' literal object.
@@ -36,7 +36,7 @@ public enum ArcKind implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	INHIBITOR(1, "Inhibitor", "http://es.unizar.dsico/pnconstants/akind/inhibitor");
+	INHIBITOR(1, "Inhibitor", "http://es.unizar.dsico/pnconstants/tkind/exponential");
 
 	/**
 	 * The '<em><b>Normal</b></em>' literal value.
@@ -47,7 +47,7 @@ public enum ArcKind implements Enumerator {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @see #NORMAL
-	 * @model name="Normal" literal="http://es.unizar.dsico/pnconstants/akind/normal"
+	 * @model name="Normal" literal="http://es.unizar.dsico/pnconstants/tkind/immediate"
 	 * @generated
 	 * @ordered
 	 */
@@ -62,7 +62,7 @@ public enum ArcKind implements Enumerator {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @see #INHIBITOR
-	 * @model name="Inhibitor" literal="http://es.unizar.dsico/pnconstants/akind/inhibitor"
+	 * @model name="Inhibitor" literal="http://es.unizar.dsico/pnconstants/tkind/exponential"
 	 * @generated
 	 * @ordered
 	 */

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/BaseUnitsConstants.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/BaseUnitsConstants.java
@@ -26,7 +26,9 @@ public enum BaseUnitsConstants implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	BASE_TIME_UNIT(0, "baseTimeUnit", "http://es.unizar.dsico/pnconstants/units/basetimeunit"), /**
+	BASE_TIME_UNIT(0, "baseTimeUnit", "http://es.unizar.dsico/pnconstants/units/basetimeunit"),
+
+	/**
 	 * The '<em><b>Base Frequency Unit</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/Color.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/Color.java
@@ -22,21 +22,21 @@ public enum Color implements Enumerator {
 	 * The '<em><b>Color</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #COLOR
+	 * @see #COLOR_VALUE
 	 * @generated
 	 * @ordered
 	 */
-	COLOR(0, "Color", "http://es.unizar.dsico/pnconstants/color/color"),
+	COLOR(0, "Color", "http://es.unizar.dsico/pnconstants/color/numcolor"),
 
 	/**
-	 * The '<em><b>ColorSet</b></em>' literal object.
+	 * The '<em><b>Color Set</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @see #COLORSET
+	 * @see #COLOR_SET_VALUE
 	 * @generated
 	 * @ordered
 	 */
-	COLORSET(1, "ColorSet", "http://es.unizar.dsico/pnconstants/color/colorset");
+	COLOR_SET(1, "ColorSet", "http://es.unizar.dsico/pnconstants/color/numelementscolor");
 
 	/**
 	 * The '<em><b>Color</b></em>' literal value.
@@ -47,26 +47,26 @@ public enum Color implements Enumerator {
 	 * </p>
 	 * <!-- end-user-doc -->
 	 * @see #COLOR
-	 * @model name="Color" literal="http://es.unizar.dsico/pnconstants/color/color"
+	 * @model name="Color" literal="http://es.unizar.dsico/pnconstants/color/numcolor"
 	 * @generated
 	 * @ordered
 	 */
 	public static final int COLOR_VALUE = 0;
-	
+
 	/**
-	 * The '<em><b>ColorSet</b></em>' literal value.
+	 * The '<em><b>Color Set</b></em>' literal value.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>ColorSet</b></em>' literal object isn't clear,
+	 * If the meaning of '<em><b>Color Set</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @see #COLORSET
-	 * @model name="ColorSet" literal="http://es.unizar.dsico/pnconstants/color/colorset"
+	 * @see #COLOR_SET
+	 * @model name="ColorSet" literal="http://es.unizar.dsico/pnconstants/color/numelementscolor"
 	 * @generated
 	 * @ordered
 	 */
-	public static final int COLORSET_VALUE = 1;
+	public static final int COLOR_SET_VALUE = 1;
 
 	/**
 	 * An array of all the '<em><b>Color</b></em>' enumerators.
@@ -77,7 +77,7 @@ public enum Color implements Enumerator {
 	private static final Color[] VALUES_ARRAY =
 		new Color[] {
 			COLOR,
-			COLORSET,
+			COLOR_SET,
 		};
 
 	/**
@@ -135,7 +135,7 @@ public enum Color implements Enumerator {
 	public static Color get(int value) {
 		switch (value) {
 			case COLOR_VALUE: return COLOR;
-			case COLORSET_VALUE: return COLORSET;
+			case COLOR_SET_VALUE: return COLOR_SET;
 		}
 		return null;
 	}

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/PnconstantsPackage.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/PnconstantsPackage.java
@@ -84,7 +84,6 @@ public interface PnconstantsPackage extends EPackage {
 	 */
 	int SERVER_TYPE = 2;
 
-
 	/**
 	 * The meta object id for the '{@link es.unizar.disco.pnextensions.pnconstants.BaseUnitsConstants <em>Base Units Constants</em>}' enum.
 	 * <!-- begin-user-doc -->
@@ -104,7 +103,7 @@ public interface PnconstantsPackage extends EPackage {
 	 * @generated
 	 */
 	int COLOR = 4;
-	
+
 	/**
 	 * The meta object id for the '{@link es.unizar.disco.pnextensions.pnconstants.ArcKind <em>Arc Kind</em>}' enum.
 	 * <!-- begin-user-doc -->
@@ -114,7 +113,8 @@ public interface PnconstantsPackage extends EPackage {
 	 * @generated
 	 */
 	int ARC_KIND = 5;
-	
+
+
 	/**
 	 * Returns the meta object for enum '{@link es.unizar.disco.pnextensions.pnconstants.ToolInfoConstants <em>Tool Info Constants</em>}'.
 	 * <!-- begin-user-doc -->
@@ -164,7 +164,7 @@ public interface PnconstantsPackage extends EPackage {
 	 * @generated
 	 */
 	EEnum getColor();
-	
+
 	/**
 	 * Returns the meta object for enum '{@link es.unizar.disco.pnextensions.pnconstants.ArcKind <em>Arc Kind</em>}'.
 	 * <!-- begin-user-doc -->
@@ -174,7 +174,7 @@ public interface PnconstantsPackage extends EPackage {
 	 * @generated
 	 */
 	EEnum getArcKind();
-	
+
 	/**
 	 * Returns the factory that creates the instances of the model.
 	 * <!-- begin-user-doc -->
@@ -237,9 +237,9 @@ public interface PnconstantsPackage extends EPackage {
 		 * @generated
 		 */
 		EEnum BASE_UNITS_CONSTANTS = eINSTANCE.getBaseUnitsConstants();
-		
+
 		/**
-		 * The meta object literal for the '{@link es.unizar.disco.pnextensions.pnconstants.BaseUnitsConstants <em>Color</em>}' enum.
+		 * The meta object literal for the '{@link es.unizar.disco.pnextensions.pnconstants.Color <em>Color</em>}' enum.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
 		 * @see es.unizar.disco.pnextensions.pnconstants.Color
@@ -248,7 +248,6 @@ public interface PnconstantsPackage extends EPackage {
 		 */
 		EEnum COLOR = eINSTANCE.getColor();
 
-		
 		/**
 		 * The meta object literal for the '{@link es.unizar.disco.pnextensions.pnconstants.ArcKind <em>Arc Kind</em>}' enum.
 		 * <!-- begin-user-doc -->
@@ -258,7 +257,6 @@ public interface PnconstantsPackage extends EPackage {
 		 * @generated
 		 */
 		EEnum ARC_KIND = eINSTANCE.getArcKind();
-
 
 	}
 

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/TransitionKind.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/TransitionKind.java
@@ -46,7 +46,9 @@ public enum TransitionKind implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	DETERMINISTIC(2, "Deterministic", "http://es.unizar.disco/pnconstants/tkind/deterministic"), /**
+	DETERMINISTIC(2, "Deterministic", "http://es.unizar.disco/pnconstants/tkind/deterministic"), 
+	
+	/**
 	 * The '<em><b>Immediate Priority</b></em>' literal object.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -54,7 +56,18 @@ public enum TransitionKind implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	IMMEDIATE_PRIORITY(3, "ImmediatePriority", "http://es.unizar.disco/pnconstants/tkind/immediatepriority");
+	IMMEDIATE_PRIORITY(3, "ImmediatePriority", "http://es.unizar.disco/pnconstants/tkind/immediatepriority"),
+	
+	/**
+	 * The '<em><b>Erlang</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #ERLANG_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	ERLANG(4, "Erlang", "http://es.unizar.disco/pnconstants/tkind/erlang");
+	
 
 	/**
 	 * The '<em><b>Immediate</b></em>' literal value.
@@ -117,6 +130,21 @@ public enum TransitionKind implements Enumerator {
 	public static final int IMMEDIATE_PRIORITY_VALUE = 3;
 
 	/**
+	 * The '<em><b>Erlang</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Erlang</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #ERLANG
+	 * @model name="Erlang" literal="http://es.unizar.disco/pnconstants/tkind/erlang"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int ERLANG_VALUE = 4;
+	
+	/**
 	 * An array of all the '<em><b>Transition Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -128,6 +156,7 @@ public enum TransitionKind implements Enumerator {
 			EXPONENTIAL,
 			DETERMINISTIC,
 			IMMEDIATE_PRIORITY,
+			ERLANG,
 		};
 
 	/**
@@ -188,6 +217,7 @@ public enum TransitionKind implements Enumerator {
 			case EXPONENTIAL_VALUE: return EXPONENTIAL;
 			case DETERMINISTIC_VALUE: return DETERMINISTIC;
 			case IMMEDIATE_PRIORITY_VALUE: return IMMEDIATE_PRIORITY;
+			case ERLANG_VALUE: return ERLANG;
 		}
 		return null;
 	}

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/TransitionKind.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/TransitionKind.java
@@ -46,8 +46,8 @@ public enum TransitionKind implements Enumerator {
 	 * @generated
 	 * @ordered
 	 */
-	DETERMINISTIC(2, "Deterministic", "http://es.unizar.disco/pnconstants/tkind/deterministic"), 
-	
+	DETERMINISTIC(2, "Deterministic", "http://es.unizar.disco/pnconstants/tkind/deterministic"),
+
 	/**
 	 * The '<em><b>Immediate Priority</b></em>' literal object.
 	 * <!-- begin-user-doc -->
@@ -57,7 +57,7 @@ public enum TransitionKind implements Enumerator {
 	 * @ordered
 	 */
 	IMMEDIATE_PRIORITY(3, "ImmediatePriority", "http://es.unizar.disco/pnconstants/tkind/immediatepriority"),
-	
+
 	/**
 	 * The '<em><b>Erlang</b></em>' literal object.
 	 * <!-- begin-user-doc -->
@@ -67,7 +67,6 @@ public enum TransitionKind implements Enumerator {
 	 * @ordered
 	 */
 	ERLANG(4, "Erlang", "http://es.unizar.disco/pnconstants/tkind/erlang");
-	
 
 	/**
 	 * The '<em><b>Immediate</b></em>' literal value.
@@ -143,7 +142,7 @@ public enum TransitionKind implements Enumerator {
 	 * @ordered
 	 */
 	public static final int ERLANG_VALUE = 4;
-	
+
 	/**
 	 * An array of all the '<em><b>Transition Kind</b></em>' enumerators.
 	 * <!-- begin-user-doc -->

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsFactoryImpl.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsFactoryImpl.java
@@ -188,6 +188,15 @@ public class PnconstantsFactoryImpl extends EFactoryImpl implements PnconstantsF
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public String convertBaseUnitsConstantsToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public Color createColorFromString(EDataType eDataType, String initialValue) {
 		Color result = Color.get(initialValue);
 		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
@@ -220,15 +229,6 @@ public class PnconstantsFactoryImpl extends EFactoryImpl implements PnconstantsF
 	 * @generated
 	 */
 	public String convertArcKindToString(EDataType eDataType, Object instanceValue) {
-		return instanceValue == null ? null : instanceValue.toString();
-	}
-	
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public String convertBaseUnitsConstantsToString(EDataType eDataType, Object instanceValue) {
 		return instanceValue == null ? null : instanceValue.toString();
 	}
 

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsPackageImpl.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsPackageImpl.java
@@ -258,6 +258,7 @@ public class PnconstantsPackageImpl extends EPackageImpl implements PnconstantsP
 		addEEnumLiteral(transitionKindEEnum, TransitionKind.EXPONENTIAL);
 		addEEnumLiteral(transitionKindEEnum, TransitionKind.DETERMINISTIC);
 		addEEnumLiteral(transitionKindEEnum, TransitionKind.IMMEDIATE_PRIORITY);
+		addEEnumLiteral(transitionKindEEnum, TransitionKind.ERLANG);
 
 		initEEnum(serverTypeEEnum, ServerType.class, "ServerType");
 		addEEnumLiteral(serverTypeEEnum, ServerType.INFINITE_SERVER);

--- a/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsPackageImpl.java
+++ b/bundles/es.unizar.disco.pnextensions/src/es/unizar/disco/pnextensions/pnconstants/impl/PnconstantsPackageImpl.java
@@ -2,14 +2,14 @@
  */
 package es.unizar.disco.pnextensions.pnconstants.impl;
 
+import es.unizar.disco.pnextensions.pnconstants.ArcKind;
 import es.unizar.disco.pnextensions.pnconstants.BaseUnitsConstants;
+import es.unizar.disco.pnextensions.pnconstants.Color;
 import es.unizar.disco.pnextensions.pnconstants.PnconstantsFactory;
 import es.unizar.disco.pnextensions.pnconstants.PnconstantsPackage;
 import es.unizar.disco.pnextensions.pnconstants.ServerType;
 import es.unizar.disco.pnextensions.pnconstants.ToolInfoConstants;
 import es.unizar.disco.pnextensions.pnconstants.TransitionKind;
-import es.unizar.disco.pnextensions.pnconstants.Color;
-import es.unizar.disco.pnextensions.pnconstants.ArcKind;
 
 import es.unizar.disco.pnextensions.pnutils.PnutilsPackage;
 
@@ -61,13 +61,14 @@ public class PnconstantsPackageImpl extends EPackageImpl implements PnconstantsP
 	 * @generated
 	 */
 	private EEnum colorEEnum = null;
-		/**
+
+	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
 	private EEnum arcKindEEnum = null;
-	
+
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
 	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
@@ -178,8 +179,8 @@ public class PnconstantsPackageImpl extends EPackageImpl implements PnconstantsP
 	public EEnum getColor() {
 		return colorEEnum;
 	}
-	
-		/**
+
+	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
@@ -187,7 +188,7 @@ public class PnconstantsPackageImpl extends EPackageImpl implements PnconstantsP
 	public EEnum getArcKind() {
 		return arcKindEEnum;
 	}
-	
+
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -269,15 +270,15 @@ public class PnconstantsPackageImpl extends EPackageImpl implements PnconstantsP
 		initEEnum(baseUnitsConstantsEEnum, BaseUnitsConstants.class, "BaseUnitsConstants");
 		addEEnumLiteral(baseUnitsConstantsEEnum, BaseUnitsConstants.BASE_TIME_UNIT);
 		addEEnumLiteral(baseUnitsConstantsEEnum, BaseUnitsConstants.BASE_FREQUENCY_UNIT);
-		
+
 		initEEnum(colorEEnum, Color.class, "Color");
 		addEEnumLiteral(colorEEnum, Color.COLOR);
-		addEEnumLiteral(colorEEnum, Color.COLORSET);
+		addEEnumLiteral(colorEEnum, Color.COLOR_SET);
 
 		initEEnum(arcKindEEnum, ArcKind.class, "ArcKind");
 		addEEnumLiteral(arcKindEEnum, ArcKind.NORMAL);
 		addEEnumLiteral(arcKindEEnum, ArcKind.INHIBITOR);
-		
+
 		// Create resource
 		createResource(eNS_URI);
 	}

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-hadoop-ad2pnml.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-hadoop-ad2pnml.qvto
@@ -1813,14 +1813,14 @@ helper colorSetToolInfo(colorset : ColourSet) : PNML::ToolInfo {
 	return object PNML::ToolInfo { 
 		tool := CONST::ToolInfoConstants::toolName.toString();
 		version := CONST::ToolInfoConstants::toolVersion.toString();
-		toolInfoGrammarURI := CONST::Color::ColorSet.toString().createURI();
+		toolInfoGrammarURI := CONST::Color::Colorset.toString().createURI();
 		formattedXMLBuffer := colorSet2String(colorset);
 	};		
 }
 
 helper colorSet2String(colorset : ColourSet) : LongString {
-	return ("<value grammar=\"" + CONST::Color::ColorSet.toString() + "\">" + colorset.colorset_id + "</value>" +
-		   "<value grammar=\"" + CONST::Color::ColorSet.toString() + "\">" + colorset.type.toString() + "</value>").createLongString();
+	return ("<value grammar=\"" + CONST::Color::Colorset.toString() + "\">" + colorset.colorset_id + "</value>" +
+		   "<value grammar=\"" + CONST::Color::Colorset.toString() + "\">" + colorset.type.toString() + "</value>").createLongString();
 }
 							   
 /**

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
@@ -525,7 +525,8 @@ mapping UML::ControlFlow::forkControlFlow2arc() when {
 mapping UML::NamedElement::namedElement2place() : PNML::Place {
 		containerPage := resolveoneIn(UML::NamedElement::model2page);
 		id := createRandomUniqueId();
-		if (self.name.oclIsUndefined().not()) {
+		if (self.name.oclIsUndefined().not() and
+			self.name.equalsIgnoreCase("").not()) {
 			name := object PNML::Name {
 				text := self.name;
 			};
@@ -656,7 +657,8 @@ inherits UML::NamedElement::namedElement2place {
 mapping UML::NamedElement::namedElement2transition() : PNML::Transition {
 		containerPage := resolveoneIn(UML::NamedElement::model2page);
 		id := createRandomUniqueId();
-		if (self.name.oclIsUndefined().not()) {
+		if (self.name.oclIsUndefined().not() and
+		 	self.name.equalsIgnoreCase("").not()) {
 			name := object PNML::Name {
 				text := self.name;
 			};

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
@@ -754,13 +754,21 @@ inherits UML::ActivityNode::activityNode2immediateTransition {
 */
 mapping UML::ActivityNode::activityNode2timedTransition() : PNML::Transition 
 inherits UML::NamedElement::namedElement2transition {
-	toolspecifics += self[OpaqueAction].map opaqueActionHostDemand2toolInfo();
+	/**/
+	var nAssigned := ad.scenario().getSparkScenario_nAssignedCores();
+	if (self.numTasks.value() > nAssigned.value()) {
+		toolspecifics += self[OpaqueAction].map opaqueActionHostDemand2toolInfo();	
+	}
+	else {
+		toolspecifics += self[OpaqueAction].map opaqueActionErlangHostDemand2toolInfo();
+	}
+	/**/
 }
 
 /***********************************************************************/
 
 /**
-	Transforms an OpaqueAction with a hostDemand annotation to a ToolInfo element
+	Transforms an OpaqueAction with a hostDemand annotation and Exponential distritution to a ToolInfo element
 */
 
 mapping UML::OpaqueAction::opaqueActionHostDemand2toolInfo() : List ( PNML::ToolInfo ) 
@@ -769,6 +777,21 @@ when {
 }{
 	var hostDemand := self.getSparkOperation_hostDemand();
 	result += expTransitionToolInfo( 1 / hostDemand.value());
+	result += infServerTransitionToolInfo();
+}
+
+/**
+	Transforms an OpaqueAction with a hostDemand annotation and Erlang distritution to a ToolInfo element
+*/
+
+mapping UML::OpaqueAction::opaqueActionErlangHostDemand2toolInfo() : List ( PNML::ToolInfo ) 
+when {
+		self.getSparkOperation_hostDemand().oclIsUndefined().not();
+}{
+	var hostDemand := self.getSparkOperation_hostDemand();
+	//var k := self.numTasks;
+	var k := ad.scenario().getSparkScenario_sparkDefaultParallelism();
+	result += erlangTransitionToolInfo(1 / hostDemand.value(), k.value() * k.value());
 	result += infServerTransitionToolInfo();
 }
 
@@ -1403,7 +1426,8 @@ helper UML::ActivityNode::inferNumTasks() : NFP_Integer {
 		};
 		
 		if (self.oclAsType(ActivityNode).isJoinOperation() or
-			self.oclAsType(ActivityNode).isRepartitionOperation()){
+			self.oclAsType(ActivityNode).isRepartitionOperation() or
+			(mapType = DBET::SparkMap::Substraction)){
 			assert warning (explicitTasks != null) with log ("Cannot infer the number of numTasks. Activity Node with Spark operation" + mapType.toString() + " requires an explicit number of numTasks");
 		};
 	};

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/dtsm-spark-ad2pnml.qvto
@@ -1117,11 +1117,11 @@ helper UML::Element::getSparkReduce_hostDemand() : NFP_Duration {
 }
 
 /******************************************************************/
-helper UML::Element::getMapType() : DBET::SparkMap {
+helper UML::Element::getMapType() : DBET::SparkTransformation {
 	if (self.getSparkMap() = null) {
 		return null;
 	};
-	var mapType := self.getValue(self.getSparkMap(), "MapType").oclAsType(DBET::SparkMap);
+	var mapType := self.getValue(self.getSparkMap(), "MapType").oclAsType(DBET::SparkTransformation);
 	assert warning (mapType->size() = 1)
 		with log ("Unexpected number of 'MapType' tagged values found, expected 1. "+
 					"The context element is '" + self.toString() + "'");
@@ -1129,11 +1129,11 @@ helper UML::Element::getMapType() : DBET::SparkMap {
 	return mapType;
 }
 
-helper UML::Element::getReduceType() : DBET::SparkReduce {
+helper UML::Element::getReduceType() : DBET::SparkAction {
 	if (self.getSparkReduce() = null) {
 		return null;
 	};
-	var reduceType := self.getValue(self.getSparkReduce(), "ReduceType").oclAsType(DBET::SparkReduce);
+	var reduceType := self.getValue(self.getSparkReduce(), "ReduceType").oclAsType(DBET::SparkAction);
 	assert warning (reduceType->size() = 1)
 		with log ("Unexpected number of 'ReduceType' tagged values found, expected 1. "+
 					"The context element is '" + self.toString() + "'");
@@ -1142,29 +1142,29 @@ helper UML::Element::getReduceType() : DBET::SparkReduce {
 }
 
 /******************************************************************/
-query isSetOperation(in mapType : DBET::SparkMap) : Boolean {
-	return (mapType = DBET::SparkMap::RDDSetOperation) or 
-		   (mapType = DBET::SparkMap::Union) or 
-		   (mapType = DBET::SparkMap::Intersection) or 
-		   (mapType = DBET::SparkMap::Substraction) or 
-		   (mapType = DBET::SparkMap::Distinct) or 
-		   (mapType = DBET::SparkMap::Cartesian) ;
+query isSetOperation(in mapType : DBET::SparkTransformation) : Boolean {
+	return (mapType = DBET::SparkTransformation::RDDSetOperation) or 
+		   (mapType = DBET::SparkTransformation::Union) or 
+		   (mapType = DBET::SparkTransformation::Intersection) or 
+		   (mapType = DBET::SparkTransformation::Substraction) or 
+		   (mapType = DBET::SparkTransformation::Distinct) or 
+		   (mapType = DBET::SparkTransformation::Cartesian) ;
 }
 
-query isByKeyOperation(in mapType : DBET::SparkMap) : Boolean {
-	return (mapType = DBET::SparkMap::ByKey);
+query isByKeyOperation(in mapType : DBET::SparkTransformation) : Boolean {
+	return (mapType = DBET::SparkTransformation::ByKey);
 }
 
-query isByKeyOperation(in redType : DBET::SparkReduce) : Boolean {
-	return (redType = DBET::SparkReduce::CountByKey);
+query isByKeyOperation(in redType : DBET::SparkAction) : Boolean {
+	return (redType = DBET::SparkAction::CountByKey);
 }
 
-query isJoinOperation(in mapType : DBET::SparkMap) : Boolean {
-	return (mapType = DBET::SparkMap::Join);
+query isJoinOperation(in mapType : DBET::SparkTransformation) : Boolean {
+	return (mapType = DBET::SparkTransformation::Join);
 }
 
-query isRepartitionOperation(in mapType : DBET::SparkMap) : Boolean {
-	return (mapType = DBET::SparkMap::Repartition);
+query isRepartitionOperation(in mapType : DBET::SparkTransformation) : Boolean {
+	return (mapType = DBET::SparkTransformation::Repartition);
 }
 
 /******************************************************************/
@@ -1404,15 +1404,15 @@ helper UML::ActivityNode::inferNumTasks() : NFP_Integer {
 			if (self.oclAsType(ActivityNode).isSetOperation()){
 				assert warning (self.incoming->size() <= 2) with log ("Activity Nodes reprepresenting set operations need two RDD");
 				var totalTasks := 1;
-				if (mapType = DBET::SparkMap::Union){			
+				if (mapType = DBET::SparkTransformation::Union){			
 					prevTasks->forEach(prevNumTasks){
 						totalTasks := totalTasks + prevNumTasks.value() - 1;
 					}
-				} else if (mapType = DBET::SparkMap::Cartesian){
+				} else if (mapType = DBET::SparkTransformation::Cartesian){
 					prevTasks->forEach(prevNumTasks){
 						totalTasks := totalTasks * prevNumTasks.value();
 					}
-				}  else if (mapType = DBET::SparkMap::Intersection){
+				}  else if (mapType = DBET::SparkTransformation::Intersection){
 					prevTasks->forEach(prevNumTasks){
 						totalTasks := max(totalTasks, prevNumTasks.value());
 						totalTasks := max(totalTasks, defaultParallelism);
@@ -1429,7 +1429,7 @@ helper UML::ActivityNode::inferNumTasks() : NFP_Integer {
 		
 		if (self.oclAsType(ActivityNode).isJoinOperation() or
 			self.oclAsType(ActivityNode).isRepartitionOperation() or
-			(mapType = DBET::SparkMap::Substraction)){
+			(mapType = DBET::SparkTransformation::Subtract)){
 			assert warning (explicitTasks != null) with log ("Cannot infer the number of numTasks. Activity Node with Spark operation" + mapType.toString() + " requires an explicit number of numTasks");
 		};
 	};

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
@@ -377,7 +377,7 @@ helper String::value() : String {
 /**
 	Helper that determines if a given String represents a CallOperationExpression
 */
-/*helper String::isExpression() : Boolean {
+helper String::isExpression() : Boolean {
 	/*
 	distribution(mean:real,....)
 	*/
@@ -388,7 +388,7 @@ helper String::value() : String {
 }
 
 /**
-	Helper that parses a CallOperationExpression and returns a Dictionary
+	Helper that parses a CallOperationExpression and returns a Sequence
 */
 helper String::asExpresion() : Sequence (String) {
 	var lowercase := self.toLowerCase(); 
@@ -428,7 +428,7 @@ helper String::asExpresion() : Sequence (String) {
 		entries += entry;
 	};
 	return entries;
-}*/
+}
 
 /**
 	Helper that determines if a given String represents a Tuple

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
@@ -170,15 +170,21 @@ helper UML::Element::getSparkOperation() : UML::Stereotype {
 }
 
 helper UML::Element::getSparkMap() : UML::Stereotype {
-	if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkMap"))) { 
+	/*if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkMap"))) { 
 		return self.getAppliedStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkMap");
+	};*/
+	if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkTransformation"))) { 
+		return self.getAppliedStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkTransformation");
 	};
 	return null;	
 }
 
 helper UML::Element::getSparkReduce() : UML::Stereotype {
-	if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkReduce"))) { 
+	/*if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkReduce"))) { 
 		return self.getAppliedStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkReduce");
+	};*/
+	if (self.isStereotypeApplied(self.getApplicableStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkAction"))) { 
+		return self.getAppliedStereotype("DICE::DICE_UML_Extensions::DTSM::Spark::SparkAction");
 	};
 	return null;	
 }

--- a/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
+++ b/bundles/es.unizar.disco.pnml.m2m/transformations/helpers.qvto
@@ -244,6 +244,37 @@ helper normalArcToolInfo() : PNML::ToolInfo {
 /********************/
 
 /**
+	Creates the ToolInfo that identifies an Erlang timed transition,
+	i.e., CONST::TransitionKind::Erlang 
+*/
+helper erlangTransitionToolInfo(rate : Real, k : Real) : PNML::ToolInfo {
+	return object PNML::ToolInfo { 
+		tool := CONST::ToolInfoConstants::toolName.toString();
+		version := CONST::ToolInfoConstants::toolVersion.toString();
+		toolInfoGrammarURI := CONST::TransitionKind::Exponential.toString().createURI();
+		formattedXMLBuffer := erlang2String(rate,k);
+	};	
+}
+
+helper erlang2String(rate : Real, k : Real) : LongString {
+	return ("<value grammar=\"" + CONST::TransitionKind::Erlang.toString() + "\">" + rate.toString() + "</value>" + 
+			"<value grammar=\"" + CONST::TransitionKind::Erlang.toString() + "\">" + k.toString() + "</value>").createLongString();
+}
+
+/**
+	Creates the ToolInfo that identifies an deterministic timed transition,
+	i.e., CONST::TransitionKind::Deterministic 
+*/
+helper determTransitionToolInfo(rate : Real) : PNML::ToolInfo {
+	return object PNML::ToolInfo { 
+		tool := CONST::ToolInfoConstants::toolName.toString();
+		version := CONST::ToolInfoConstants::toolVersion.toString();
+		toolInfoGrammarURI := CONST::TransitionKind::Exponential.toString().createURI();
+		formattedXMLBuffer := ("<value grammar=\"" + CONST::TransitionKind::Deterministic.toString() + "\">" + rate.toString() + "</value>").createLongString();
+	};	
+}
+
+/**
 	Creates the ToolInfo that identifies an exponential timed transition,
 	i.e., CONST::TransitionKind::Exponential 
 */
@@ -255,8 +286,6 @@ helper expTransitionToolInfo(rate : Real) : PNML::ToolInfo {
 		formattedXMLBuffer := ("<value grammar=\"" + CONST::TransitionKind::Exponential.toString() + "\">" + rate.toString() + "</value>").createLongString();
 	};	
 }
-
-
 
 /**
 	Creates the ToolInfo that identifies an InfiniteServer timed transition,
@@ -344,6 +373,62 @@ helper String::value() : String {
 	assert fatal (self.indexOf("=") <> -1) with log ("Unexpected number of tokens in " + self);
 	return self.substringAfter("=").trim()
 }
+
+/**
+	Helper that determines if a given String represents a CallOperationExpression
+*/
+/*helper String::isExpression() : Boolean {
+	/*
+	distribution(mean:real,....)
+	*/
+	var trimmed := self.trim();
+	return ((trimmed.indexOf("(") > 1) and 
+			(trimmed.indexOf("(") < trimmed.size())) and 
+			trimmed.trim().endsWith(")");
+}
+
+/**
+	Helper that parses a CallOperationExpression and returns a Dictionary
+*/
+helper String::asExpresion() : Sequence (String) {
+	var lowercase := self.toLowerCase(); 
+	var trimmed := lowercase.trim();
+	assert warning ((trimmed.indexOf("(") > 1) and 
+					(trimmed.indexOf("(") < trimmed.size()))
+		   with log ("Tuple string '" + self + "' does not contain '('");
+	assert warning (trimmed.trim().endsWith(")")) with log ("Tuple string '" + self + "' does not end with ')'");
+
+	/**/
+	var firstPar : Integer := trimmed.indexOf("(");
+	var distribution : String := trimmed.substring(1, firstPar);
+	/**/
+	var segments : List (String) := List {};
+	var pars : Integer := 0;
+	var segment : String;
+	segments->add(distribution);
+	trimmed.substring(firstPar, trimmed.size() - 1).characters()->forEach(c) {
+		switch {
+			case (c = '(') {
+				pars := pars + 1;
+			} case (c = ')') {
+				pars := pars - 1;
+			} case (c = ',') {
+				if (pars = 0) { 
+					segments->add(segment);
+					segment := '';
+					continue;
+				}
+			}
+		};
+		segment := segment.concat(c);
+	};
+	segments->add(segment);
+	var entries : Sequence (String) := Sequence {};
+	segments->forEach(entry) {
+		entries += entry;
+	};
+	return entries;
+}*/
 
 /**
 	Helper that determines if a given String represents a Tuple

--- a/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspn.mtl
+++ b/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspn.mtl
@@ -2,9 +2,11 @@
 [module generateGspn('http:///ptnet.ecore')]
 [import es::unizar::disco::pnml::m2t::templates::gspn::generateGspnDefFile /]
 [import es::unizar::disco::pnml::m2t::templates::gspn::generateGspnNetFile /]
+[import es::unizar::disco::pnml::m2t::templates::gspn::generateGspnDisFile /]
 
 [template public generateGspn(petriNet : PetriNet)]
 [comment @main /]
 [generateGspnDefFile(petriNet) /]
 [generateGspnNetFile(petriNet) /]
+[generateGspnDisFile(petriNet) /]
 [/template]

--- a/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspnDisFile.mtl
+++ b/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspnDisFile.mtl
@@ -1,0 +1,70 @@
+[comment encoding = UTF-8 /]
+[module generateGspnDisFile('http:///ptnet.ecore')]
+
+[template public generateGspnDisFile(petriNet : PetriNet) post(trim())]
+[file (petriNet.id.concat('.dis'), false, 'Cp1252')]
+[rowDef(petriNet)/]
+[/file]
+[/template]
+
+[template public rowDef(petriNet : PetriNet) post (trim())]
+[comment ROW ::= TR_NAME FIRING_POL RESCHEDULE_POL DESCHEDULE_POL DISTRIB /]
+[for (trans : Transition | allTransitions(petriNet))]
+[if isDeterministic(trans)]
+[trans.id/] [tFire(trans)/] [tResche(trans)/] [tDesche(trans)/] [tDist(trans)/]
+[/if]
+[if isErlang(trans)]
+[trans.id/] [tFire(trans)/] [tResche(trans)/] [tDesche(trans)/] [tDist(trans)/]
+[/if][/for]
+[/template]
+
+[template public tFire(trans : Transition) post (trim())]
+[comment FIRING_POL ::= AGE | ENABLING /]
+ENABLING
+[/template]
+
+[template public tResche(trans : Transition) post (trim())]
+[comment POL ::= RANDOM | FIRST_DRAWN | LAST_DRAWN | FIRST_SCHED | LAST_SCHED /]
+RANDOM
+[/template]
+
+[template public tDesche(trans : Transition) post (trim())]
+[comment POL ::= RANDOM | FIRST_DRAWN | LAST_DRAWN | FIRST_SCHED | LAST_SCHED /]
+RANDOM
+[/template]
+
+[template public tDist(trans : Transition) post (trim())]
+[comment DISTRIB ::= DET | ERL N_STAGE |
+					 IPO N_STAGE #(N_STAGE) {RATE} |
+					 IPER N_STAGE #(N_STAGE) {PROB RATE} |
+					 UNIF LOWER_UPPER |
+					 NORM MEAN DEVSTD |
+					 BAR N_UNIF #(N_UNIF) {LOWER UPPER PROB} |
+ /]
+[if isDeterministic(trans)] DET [/if]
+[if isErlang(trans)] ERL [getTransitionErlangK(trans)/] [/if]
+[/template]
+
+[query public allTransitions(petriNet : PetriNet) : Collection(Transition) =
+	petriNet.pages.objects->flatten()->selectByKind(Transition)->sortedBy(id)
+/]
+
+[query public isExponential(trans : Transition) : Boolean =
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isExponential(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public isDeterministic(trans : Transition) : Boolean =
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isDeterministic(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public isErlang(trans : Transition) : Boolean =
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isErlang(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public getTransitionErlangK(trans : Transition) : Integer = 
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','getTransitionErlangK(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]

--- a/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspnNetFile.mtl
+++ b/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/templates/gspn/generateGspnNetFile.mtl
@@ -163,6 +163,10 @@ f 0 [countPlaces(petriNet)/] 0 [countTransitions(petriNet)/] [countPriorityGroup
 [template public tRate(trans : Transition) post (trim())]
 [if (isExponential(trans))]
 [getRate(trans)/]
+[elseif (isDeterministic(trans))]
+[getDeterministicRate(trans)/]
+[elseif (isErlang(trans))]
+[getErlangRate(trans)/]
 [elseif (isImmediate(trans))]
 [getProbability(trans)/]
 [else]
@@ -181,7 +185,7 @@ f 0 [countPlaces(petriNet)/] 0 [countTransitions(petriNet)/] [countPriorityGroup
 [/template]
 
 [template public tKind(trans : Transition) post (trim())]
-[if (isExponential(trans))]
+[if (isExponential(trans)) or (isDeterministic(trans)) or (isErlang(trans))]
 0
 [elseif (isImmediate(trans))]
 [comment Implementation for isImmediate is that everything that is not deterministic or exponential, it is immediate/]
@@ -338,6 +342,16 @@ invoke('es.unizar.disco.pnml.m2t.utils.PlaceRegistry','priorityNotAdded(fr.lip6.
 	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','getTransitionRate(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
 /]
 
+[query public getDeterministicRate(trans : Transition) : Real = 
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','getTransitionDeterministicRate(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public getErlangRate(trans : Transition) : Real = 
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','getTransitionErlangRate(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
 [query public getProbability(trans : Transition) : Real = 
 	-- ToolInfo-related queries are executed via the global utility methods
 	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','getTransitionProbability(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
@@ -350,6 +364,16 @@ invoke('es.unizar.disco.pnml.m2t.utils.PlaceRegistry','priorityNotAdded(fr.lip6.
 [query public isExponential(trans : Transition) : Boolean =
 	-- ToolInfo-related queries are executed via the global utility methods
 	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isExponential(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public isDeterministic(trans : Transition) : Boolean =
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isDeterministic(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
+/]
+
+[query public isErlang(trans : Transition) : Boolean =
+	-- ToolInfo-related queries are executed via the global utility methods
+	invoke('es.unizar.disco.pnml.m2t.utils.PnmlToolInfoUtils','isErlang(fr.lip6.move.pnml.ptnet.Transition)', Sequence{trans})
 /]
 
 [query public isImmediate(trans : Transition) : Boolean = 

--- a/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/utils/PnmlToolInfoUtils.java
+++ b/bundles/es.unizar.disco.pnml.m2t/src/es/unizar/disco/pnml/m2t/utils/PnmlToolInfoUtils.java
@@ -26,8 +26,10 @@ public class PnmlToolInfoUtils {
 	public static final String VALUE_PATTERN = "<value grammar=\"(.+)\">(.+)</value>";
 	private static final String SERVER_TYPE_PATTERN = "<value grammar=\"(.+)\"/>";
 	private static final String COLOR_PATTERN = "<value grammar=\"([^>]+)\">([^<]+)</value>";
-	private static final String ARC_TYPE_PATTERN = "<value grammar=\"(.+)\"/>"; /**/
-
+	private static final String ARC_TYPE_PATTERN = "<value grammar=\"(.+)\"/>"; 
+	/**/
+	private static final String ERLANG_PATTERN = "<value grammar=\"([^>]+)\">([^<]+)</value>";
+	/**/
 	public PnmlToolInfoUtils() {
 	}
 
@@ -43,6 +45,29 @@ public class PnmlToolInfoUtils {
 		return false;
 	}
 
+	public static boolean isDeterministic(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
+			if (matcher.matches()) {
+				if (TransitionKind.DETERMINISTIC.getLiteral().equals(matcher.group(1))) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+	
+	public static boolean isErlang(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(ERLANG_PATTERN).matcher(info.getFormattedXMLBuffer());
+			boolean find = matcher.find();
+			if ( find && TransitionKind.ERLANG.getLiteral().equals(matcher.group(1)) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	public static boolean isImmediatePriority(Transition transition) throws IllegalArgumentException {
 		for (ToolInfo info : transition.getToolspecifics()) {
 			Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
@@ -59,6 +84,7 @@ public class PnmlToolInfoUtils {
 		Set<String> otherTransitionKinds = new HashSet<>();
 		otherTransitionKinds.add(TransitionKind.EXPONENTIAL.getLiteral());
 		otherTransitionKinds.add(TransitionKind.DETERMINISTIC.getLiteral());
+		otherTransitionKinds.add(TransitionKind.ERLANG.getLiteral());
 
 		for (ToolInfo info : transition.getToolspecifics()) {
 			Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
@@ -106,6 +132,55 @@ public class PnmlToolInfoUtils {
 		return 1f;
 	}
 
+	public Float getTransitionDeterministicRate(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
+			if (matcher.matches() && TransitionKind.DETERMINISTIC.getLiteral().equals(matcher.group(1))) {
+				return Float.valueOf(matcher.group(2));
+			}
+		}
+		return 1f;
+	}
+	
+	public Integer getTransitionErlangRate2(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(ERLANG_PATTERN).matcher(info.getFormattedXMLBuffer());
+			//Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
+			if (matcher.matches() && TransitionKind.ERLANG.getLiteral().equals(matcher.group(1))) {
+				return Integer.valueOf(matcher.group(2));
+			}
+		}
+		return 1;
+	}
+	
+	public Float getTransitionErlangRate(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(ERLANG_PATTERN).matcher(info.getFormattedXMLBuffer());
+			//Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
+			boolean find = matcher.find();
+			if (find && TransitionKind.ERLANG.getLiteral().equals(matcher.group(1))) {
+				float v1 = Float.valueOf(matcher.group(2)); 
+				return v1;
+			}
+		}
+		return 1f;
+	}
+	
+	public Integer getTransitionErlangK(Transition transition) throws IllegalArgumentException {
+		for (ToolInfo info : transition.getToolspecifics()) {
+			Matcher matcher = Pattern.compile(ERLANG_PATTERN).matcher(info.getFormattedXMLBuffer());
+			//Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());
+			matcher.find();
+			boolean find = matcher.find();
+			//matcher.find(2) 
+			if (find && TransitionKind.ERLANG.getLiteral().equals(matcher.group(1))) {
+				return Integer.valueOf(matcher.group(2));
+			}
+		}
+		return 1;
+	}
+	
+	
 	public Float getTransitionProbability(Transition transition) throws IllegalArgumentException {
 		for (ToolInfo info : transition.getToolspecifics()) {
 			Matcher matcher = Pattern.compile(VALUE_PATTERN).matcher(info.getFormattedXMLBuffer());

--- a/bundles/es.unizar.disco.simulation.greatspn.ssh/src/es/unizar/disco/simulation/greatspn/ssh/simulator/GspnSshSimulator.java
+++ b/bundles/es.unizar.disco.simulation.greatspn.ssh/src/es/unizar/disco/simulation/greatspn/ssh/simulator/GspnSshSimulator.java
@@ -624,8 +624,11 @@ public class GspnSshSimulator implements ISimulator {
 		GenerateGspn gspnGenerator = new GenerateGspn(model, targetDir, new ArrayList<EObject>());
 		AcceleoPreferences.switchForceDeactivationNotifications(true);
 		gspnGenerator.doGenerate(BasicMonitor.toMonitor(subMonitor.newChild(1)));
+		/*return new File[] { targetDir.toPath().resolve(model.getId() + ".net").toFile(),
+				targetDir.toPath().resolve(model.getId() + ".def").toFile() };*/
 		return new File[] { targetDir.toPath().resolve(model.getId() + ".net").toFile(),
-				targetDir.toPath().resolve(model.getId() + ".def").toFile() };
+		targetDir.toPath().resolve(model.getId() + ".def").toFile(),
+		targetDir.toPath().resolve(model.getId() + ".dis").toFile() };
 	}
 
 	private static final String VALUE_PATTERN = "<value grammar=\"(.+)\">(.+)</value>";

--- a/tests/dtsm_spark_test/extended/model_aggregate_key.uml
+++ b/tests/dtsm_spark_test/extended/model_aggregate_key.uml
@@ -91,15 +91,15 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" MapType="ByKey">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" MapType="ByKey">
     <hostDemand>(expr=$redbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/extended/model_aggregate_key_int.notation
+++ b/tests/dtsm_spark_test/extended/model_aggregate_key_int.notation
@@ -333,9 +333,4 @@
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_THhY0STcEeeGiOkBV7ej3g" id="(0.0,0.6666666666666666)"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_H9eiQCTcEeeGiOkBV7ej3g" type="PapyrusUMLActivityDiagram" measurementUnit="Pixel">
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_H9eiQSTcEeeGiOkBV7ej3g" name="diagram_compatibility_version" stringValue="1.2.0"/>
-    <styles xmi:type="notation:DiagramStyle" xmi:id="_H9eiQiTcEeeGiOkBV7ej3g"/>
-    <element xmi:type="uml:OpaqueAction" href="model_aggregate_key_int.uml#_QOIXoBfoEeePpehjS1zFvA"/>
-  </notation:Diagram>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/extended/model_aggregate_key_int.uml
+++ b/tests/dtsm_spark_test/extended/model_aggregate_key_int.uml
@@ -89,12 +89,12 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" MapType="ByKey">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" MapType="ByKey">
     <hostDemand>(expr=$redbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/extended/model_count.uml
+++ b/tests/dtsm_spark_test/extended/model_count.uml
@@ -85,9 +85,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/extended/model_count_filter.uml
+++ b/tests/dtsm_spark_test/extended/model_count_filter.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -113,7 +113,7 @@
     <respT>(expr=$RT,unit=ms,statQ=mean,source=calc)</respT>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="Filter">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="Filter">
     <hostDemand>(expr=$filterT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/extended/model_naive.uml
+++ b/tests/dtsm_spark_test/extended/model_naive.uml
@@ -93,18 +93,18 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$map2T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$map1T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$groupT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/extended/model_pi.uml
+++ b/tests/dtsm_spark_test/extended/model_pi.uml
@@ -89,12 +89,12 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$redT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/extended/model_primes.uml
+++ b/tests/dtsm_spark_test/extended/model_primes.uml
@@ -97,18 +97,18 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$substractT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$flatmapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$map1T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$repartitionT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -135,7 +135,7 @@
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
   <Spark:SparkWorkloadEvent xmi:id="_2nsW0CUKEeeGiOkBV7ej3g" base_NamedElement="_2nqhoCUKEeeGiOkBV7ej3g" sparkPopulation="$nC2" sparkExtDelay="$th2"/>
-  <Spark:SparkMap xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
+  <Spark:SparkTransformation xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
     <hostDemand>(expr=$map2T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/extended/model_scheduler_througput.uml
+++ b/tests/dtsm_spark_test/extended/model_scheduler_througput.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -113,7 +113,7 @@
     <respT>(expr=$RT,unit=ms,statQ=mean,source=calc)</respT>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/extended/model_sortbykey.uml
+++ b/tests/dtsm_spark_test/extended/model_sortbykey.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -113,7 +113,7 @@
     <respT>(expr=$RT,unit=ms,statQ=mean,source=calc)</respT>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="ByKey">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="ByKey">
     <hostDemand>(expr=$sortbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/extended/model_sortbykey_int.uml
+++ b/tests/dtsm_spark_test/extended/model_sortbykey_int.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -113,7 +113,7 @@
     <respT>(expr=$RT,unit=ms,statQ=mean,source=calc)</respT>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="ByKey">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" MapType="ByKey">
     <hostDemand>(expr=$sortbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/model.uml
+++ b/tests/dtsm_spark_test/model.uml
@@ -152,12 +152,13 @@ sparkExtDelay=[$th1]}</body>
     <context>out$T</context>
     <context>out$U</context>
     <context>out$U1</context>
+    <context>$defaultParallelism</context>
   </GQAM:GaAnalysisContext>
   <Spark:SparkWorkloadEvent xmi:id="_xAw4AAMzEeec2YL9FlAkDw" base_NamedElement="_p15FUDlXEeaE4deiM0Jlvg" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
   <Spark:SparkReduce xmi:id="_zhtKwAMzEeec2YL9FlAkDw" base_NamedElement="_vVW-sDlXEeaE4deiM0Jlvg" base_Action="_vVW-sDlXEeaE4deiM0Jlvg" OpType="Action">
     <hostDemand>(expr=$redT,unit=ms,statQ=mean,source=est)</hostDemand>
   </Spark:SparkReduce>
-  <Spark:SparkScenario xmi:id="_0_4Y8AMzEeec2YL9FlAkDw" base_NamedElement="_WuYo8DlXEeaE4deiM0Jlvg" usedResources="_6kBW8AMzEeec2YL9FlAkDw" base_Behavior="_WuYo8DlXEeaE4deiM0Jlvg" nAssignedCores="$nAssignedCores" nAssignedMemory="$nAssignedMem">
+  <Spark:SparkScenario xmi:id="_0_4Y8AMzEeec2YL9FlAkDw" base_NamedElement="_WuYo8DlXEeaE4deiM0Jlvg" usedResources="_6kBW8AMzEeec2YL9FlAkDw" base_Behavior="_WuYo8DlXEeaE4deiM0Jlvg" nAssignedCores="$nAssignedCores" nAssignedMemory="$nAssignedMem" sparkDefaultParallelism="$defaultParallelism">
     <throughput>(expr=$T,unit=s,statQ=mean,source=calc)</throughput>
     <respT>(expr=$RT,unit=s,statQ=mean,source=calc)</respT>
   </Spark:SparkScenario>

--- a/tests/dtsm_spark_test/model.uml
+++ b/tests/dtsm_spark_test/model.uml
@@ -155,9 +155,9 @@ sparkExtDelay=[$th1]}</body>
     <context>$defaultParallelism</context>
   </GQAM:GaAnalysisContext>
   <Spark:SparkWorkloadEvent xmi:id="_xAw4AAMzEeec2YL9FlAkDw" base_NamedElement="_p15FUDlXEeaE4deiM0Jlvg" sparkPopulation="$nC1" sparkExtDelay="$th1"/>
-  <Spark:SparkReduce xmi:id="_zhtKwAMzEeec2YL9FlAkDw" base_NamedElement="_vVW-sDlXEeaE4deiM0Jlvg" base_Action="_vVW-sDlXEeaE4deiM0Jlvg" OpType="Action">
+  <Spark:SparkAction xmi:id="_zhtKwAMzEeec2YL9FlAkDw" base_NamedElement="_vVW-sDlXEeaE4deiM0Jlvg" base_Action="_vVW-sDlXEeaE4deiM0Jlvg" OpType="Action">
     <hostDemand>(expr=$redT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkScenario xmi:id="_0_4Y8AMzEeec2YL9FlAkDw" base_NamedElement="_WuYo8DlXEeaE4deiM0Jlvg" usedResources="_6kBW8AMzEeec2YL9FlAkDw" base_Behavior="_WuYo8DlXEeaE4deiM0Jlvg" nAssignedCores="$nAssignedCores" nAssignedMemory="$nAssignedMem" sparkDefaultParallelism="$defaultParallelism">
     <throughput>(expr=$T,unit=s,statQ=mean,source=calc)</throughput>
     <respT>(expr=$RT,unit=s,statQ=mean,source=calc)</respT>
@@ -165,7 +165,7 @@ sparkExtDelay=[$th1]}</body>
   <Spark:SparkNode xmi:id="_6kBW8AMzEeec2YL9FlAkDw" base_Classifier="_LGzO4DlkEeaE4deiM0Jlvg" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$U,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
-  <Spark:SparkMap xmi:id="_aNzKoANAEeeSnsiFmFrbqA" base_NamedElement="_uZmhEDlXEeaE4deiM0Jlvg" base_Action="_uZmhEDlXEeaE4deiM0Jlvg">
+  <Spark:SparkTransformation xmi:id="_aNzKoANAEeeSnsiFmFrbqA" base_NamedElement="_uZmhEDlXEeaE4deiM0Jlvg" base_Action="_uZmhEDlXEeaE4deiM0Jlvg">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/model_fork_join.uml
+++ b/tests/dtsm_spark_test/model_fork_join.uml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:GQAM="http://www.eclipse.org/papyrus/GQAM/1" xmlns:Spark="http://es.unizar.disco.dice/profiles/DTSM/Spark/1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http://www.eclipse.org/papyrus/GQAM/1 http://www.eclipse.org/papyrus/MARTE/1#//GQAM">
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:GQAM="http://www.eclipse.org/papyrus/GQAM/1" xmlns:Spark="http://es.unizar.disco.dice/profiles/DTSM/Spark/1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http://www.eclipse.org/papyrus/GQAM/1 http://www.eclipse.org/papyrus/MARTE/1#//GQAM http://es.unizar.disco.dice/profiles/DTSM/Spark/1.0 http://es.unizar.disco.dice/profiles/DICE/1.0#//Spark">
   <uml:Model xmi:id="_RSOiQDlXEeaE4deiM0Jlvg" name="RootElement">
     <ownedComment xmi:type="uml:Comment" xmi:id="_ep4M8DlkEeaE4deiM0Jlvg" annotatedElement="_LGzO4DlkEeaE4deiM0Jlvg">
       <body>{nCores=[$nP1];
@@ -31,7 +31,7 @@ nMemory=[$nM1]}</body>
     </packagedElement>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_csWcMDlXEeaE4deiM0Jlvg">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_csY4cDlXEeaE4deiM0Jlvg" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="http://es.unizar.disco.dice/profiles/DPIM/1.0#/"/>
+        <references xmi:type="ecore:EPackage" href="http://es.unizar.disco.dice/profiles/DICE/1.0#//DPIM"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="pathmap://DICE_PROFILES/DICE.profile.uml#_gFr1YOebEeWj7ZPL8JeBTQ"/>
     </profileApplication>
@@ -121,7 +121,7 @@ nMemory=[$nM1]}</body>
     </profileApplication>
     <profileApplication xmi:type="uml:ProfileApplication" xmi:id="_tlENMAMzEeec2YL9FlAkDw">
       <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_tlK64AMzEeec2YL9FlAkDw" source="http://www.eclipse.org/uml2/2.0.0/UML">
-        <references xmi:type="ecore:EPackage" href="http://es.unizar.disco.dice/profiles/DTSM/Spark/1.0#/"/>
+        <references xmi:type="ecore:EPackage" href="http://es.unizar.disco.dice/profiles/DICE/1.0#//Spark"/>
       </eAnnotations>
       <appliedProfile xmi:type="uml:Profile" href="pathmap://DICE_PROFILES/DICE.profile.uml#_uVw8sPjzEeaT8NXWw3z-XA"/>
     </profileApplication>
@@ -142,10 +142,10 @@ nMemory=[$nM1]}</body>
     <context>$defaultParallelism</context>
   </GQAM:GaAnalysisContext>
   <Spark:SparkWorkloadEvent xmi:id="_xAw4AAMzEeec2YL9FlAkDw" pattern="" base_NamedElement="_p15FUDlXEeaE4deiM0Jlvg" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkReduce xmi:id="_zhtKwAMzEeec2YL9FlAkDw" base_NamedElement="_vVW-sDlXEeaE4deiM0Jlvg" base_Action="_vVW-sDlXEeaE4deiM0Jlvg" OpType="Action">
+  <Spark:SparkAction xmi:id="_zhtKwAMzEeec2YL9FlAkDw" base_NamedElement="_vVW-sDlXEeaE4deiM0Jlvg" base_Action="_vVW-sDlXEeaE4deiM0Jlvg" OpType="Action">
     <hostDemand>(expr=$redT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkScenario xmi:id="_0_4Y8AMzEeec2YL9FlAkDw" base_NamedElement="_WuYo8DlXEeaE4deiM0Jlvg" usedResources="_6kBW8AMzEeec2YL9FlAkDw" base_Behavior="_WuYo8DlXEeaE4deiM0Jlvg" nAssignedCores="$nAssignedCores" nAssignedMemory="$nAssignedMem" sparkDefaultParallelism="$defaultParallelism">
+  </Spark:SparkAction>
+  <Spark:SparkScenario xmi:id="_0_4Y8AMzEeec2YL9FlAkDw" base_NamedElement="_WuYo8DlXEeaE4deiM0Jlvg" base_Behavior="_WuYo8DlXEeaE4deiM0Jlvg" nAssignedCores="$nAssignedCores" nAssignedMemory="$nAssignedMem" sparkDefaultParallelism="$defaultParallelism">
     <throughput>(expr=$T,unit=s,statQ=mean,source=calc)</throughput>
     <respT>(expr=$RT,unit=s,statQ=mean,source=calc)</respT>
     <utilization>(expr=$USpark,unit=s,statQ=mean,source=calc)</utilization>
@@ -153,13 +153,13 @@ nMemory=[$nM1]}</body>
   <Spark:SparkNode xmi:id="_6kBW8AMzEeec2YL9FlAkDw" base_Classifier="_LGzO4DlkEeaE4deiM0Jlvg" base_NamedElement="_LGzO4DlkEeaE4deiM0Jlvg" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
-  <Spark:SparkMap xmi:id="_aNzKoANAEeeSnsiFmFrbqA" base_NamedElement="_uZmhEDlXEeaE4deiM0Jlvg" base_Action="_uZmhEDlXEeaE4deiM0Jlvg">
+  <Spark:SparkTransformation xmi:id="_aNzKoANAEeeSnsiFmFrbqA" base_NamedElement="_uZmhEDlXEeaE4deiM0Jlvg" base_Action="_uZmhEDlXEeaE4deiM0Jlvg">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hS9SwBLTEeeGS6KWmiB_xw" base_NamedElement="_hR0qUBLTEeeGS6KWmiB_xw" base_Action="_hR0qUBLTEeeGS6KWmiB_xw">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hS9SwBLTEeeGS6KWmiB_xw" base_NamedElement="_hR0qUBLTEeeGS6KWmiB_xw" base_Action="_hR0qUBLTEeeGS6KWmiB_xw">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_mTl7EBLTEeeGS6KWmiB_xw" base_NamedElement="_mTi3wBLTEeeGS6KWmiB_xw" base_Action="_mTi3wBLTEeeGS6KWmiB_xw">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_mTl7EBLTEeeGS6KWmiB_xw" base_NamedElement="_mTi3wBLTEeeGS6KWmiB_xw" base_Action="_mTi3wBLTEeeGS6KWmiB_xw">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_aggregate_key.uml
+++ b/tests/dtsm_spark_test/standard/model_aggregate_key.uml
@@ -91,15 +91,15 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA" numTasks="$nC1">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA" numTasks="$nC1">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="ByKey">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="ByKey">
     <hostDemand>(expr=$redbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/standard/model_aggregate_key_int.notation
+++ b/tests/dtsm_spark_test/standard/model_aggregate_key_int.notation
@@ -333,9 +333,4 @@
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_THhY0STcEeeGiOkBV7ej3g" id="(0.0,0.6666666666666666)"/>
     </edges>
   </notation:Diagram>
-  <notation:Diagram xmi:id="_H9eiQCTcEeeGiOkBV7ej3g" type="PapyrusUMLActivityDiagram" measurementUnit="Pixel">
-    <styles xmi:type="notation:StringValueStyle" xmi:id="_H9eiQSTcEeeGiOkBV7ej3g" name="diagram_compatibility_version" stringValue="1.2.0"/>
-    <styles xmi:type="notation:DiagramStyle" xmi:id="_H9eiQiTcEeeGiOkBV7ej3g"/>
-    <element xmi:type="uml:OpaqueAction" href="model_aggregate_key_int.uml#_QOIXoBfoEeePpehjS1zFvA"/>
-  </notation:Diagram>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_aggregate_key_int.uml
+++ b/tests/dtsm_spark_test/standard/model_aggregate_key_int.uml
@@ -89,12 +89,12 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="ByKey">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="ByKey">
     <hostDemand>(expr=$redbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/standard/model_count.uml
+++ b/tests/dtsm_spark_test/standard/model_count.uml
@@ -85,9 +85,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/standard/model_count_filter.uml
+++ b/tests/dtsm_spark_test/standard/model_count_filter.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -116,7 +116,7 @@
     <utilization>(expr=$USpark,statQ=mean,source=calc)</utilization>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1" MapType="Filter">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1" MapType="Filter">
     <hostDemand>(expr=$filterT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_naive.uml
+++ b/tests/dtsm_spark_test/standard/model_naive.uml
@@ -93,18 +93,18 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$defaultParallelism" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$defaultParallelism" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA" numTasks="$nC1">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA" numTasks="$nC1">
     <hostDemand>(expr=$map2T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA" numTasks="$nC1">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA" numTasks="$nC1">
     <hostDemand>(expr=$map1T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1">
     <hostDemand>(expr=$groupT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/standard/model_pi.uml
+++ b/tests/dtsm_spark_test/standard/model_pi.uml
@@ -89,12 +89,12 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$redT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>

--- a/tests/dtsm_spark_test/standard/model_primes.uml
+++ b/tests/dtsm_spark_test/standard/model_primes.uml
@@ -97,18 +97,18 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
     <hostDemand>(expr=$substractT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$flatmapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$map1T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$defaultParallelism" MapType="Repartition">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$defaultParallelism" MapType="Repartition">
     <hostDemand>(expr=$repartitionT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -139,7 +139,7 @@
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
   <Spark:SparkWorkloadEvent xmi:id="_2nsW0CUKEeeGiOkBV7ej3g" base_NamedElement="_2nqhoCUKEeeGiOkBV7ej3g" sparkPopulation="$nC2" sparkExtDelay="(expr=$th2,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
+  <Spark:SparkTransformation xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
     <hostDemand>(expr=$map2T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_primes2.uml
+++ b/tests/dtsm_spark_test/standard/model_primes2.uml
@@ -40,9 +40,9 @@ statQ=mean,
 source=est)}</body>
       </ownedComment>
       <ownedComment xmi:type="uml:Comment" xmi:id="_uamDAEVKEeeNJNO26xv_hg" annotatedElement="_2w2sABfnEeePpehjS1zFvA">
-        <body>{ReduceType=Substract
+        <body>{ReduceType=Subtract
 numTasks=$nC1
-hostDemand=(expr=$substractT,
+hostDemand=(expr=$subtractT,
 unit=ms,
 statQ=mean,
 source=est)}</body>
@@ -82,7 +82,7 @@ source=est)}</body>
       <group xmi:type="uml:ActivityPartition" xmi:id="_c3AZIBfnEeePpehjS1zFvA" name="Transformation" node="_N5vTIBfoEeePpehjS1zFvA _QOIXoBfoEeePpehjS1zFvA _TVg_UBfoEeePpehjS1zFvA _2np6kCUKEeeGiOkBV7ej3g" represents="_eY8icBfmEeePpehjS1zFvA"/>
       <group xmi:type="uml:ActivityPartition" xmi:id="_n_4yEBfnEeePpehjS1zFvA" name="Action" node="_2w2sABfnEeePpehjS1zFvA _oQztgDoWEeeGuLHbg3prBg" represents="_ad_v0BfmEeePpehjS1zFvA"/>
       <node xmi:type="uml:InitialNode" xmi:id="_FexHYBfnEeePpehjS1zFvA" name="Composite" outgoing="_on8bIBfoEeePpehjS1zFvA"/>
-      <node xmi:type="uml:OpaqueAction" xmi:id="_2w2sABfnEeePpehjS1zFvA" name="Substract" incoming="_Igx4QCULEeeGiOkBV7ej3g _KI9-ECULEeeGiOkBV7ej3g" outgoing="_KyRrkBfrEeePpehjS1zFvA" inPartition="_n_4yEBfnEeePpehjS1zFvA"/>
+      <node xmi:type="uml:OpaqueAction" xmi:id="_2w2sABfnEeePpehjS1zFvA" name="Subtract" incoming="_Igx4QCULEeeGiOkBV7ej3g _KI9-ECULEeeGiOkBV7ej3g" outgoing="_KyRrkBfrEeePpehjS1zFvA" inPartition="_n_4yEBfnEeePpehjS1zFvA"/>
       <node xmi:type="uml:OpaqueAction" xmi:id="_N5vTIBfoEeePpehjS1zFvA" name="Map1" incoming="_on8bIBfoEeePpehjS1zFvA" outgoing="_qKDHEBfoEeePpehjS1zFvA" inPartition="_c3AZIBfnEeePpehjS1zFvA"/>
       <node xmi:type="uml:OpaqueAction" xmi:id="_QOIXoBfoEeePpehjS1zFvA" name="Repartition" incoming="_qKDHEBfoEeePpehjS1zFvA" outgoing="_ra0LYBfoEeePpehjS1zFvA" inPartition="_c3AZIBfnEeePpehjS1zFvA"/>
       <node xmi:type="uml:OpaqueAction" xmi:id="_TVg_UBfoEeePpehjS1zFvA" name="FlatMap" incoming="_ra0LYBfoEeePpehjS1zFvA" outgoing="_smtWwBfoEeePpehjS1zFvA" inPartition="_c3AZIBfnEeePpehjS1zFvA"/>
@@ -168,18 +168,18 @@ source=est)}</body>
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
-    <hostDemand>(expr=$substractT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
-  <Spark:SparkMap xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" OpType="Action">
+    <hostDemand>(expr=$subtractT,unit=ms,statQ=mean,source=est)</hostDemand>
+  </Spark:SparkAction>
+  <Spark:SparkTransformation xmi:id="_ezllIBfoEeePpehjS1zFvA" base_NamedElement="_TVg_UBfoEeePpehjS1zFvA" base_Action="_TVg_UBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$flatmapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_hJdQUBfoEeePpehjS1zFvA" base_NamedElement="_N5vTIBfoEeePpehjS1zFvA" base_Action="_N5vTIBfoEeePpehjS1zFvA">
     <hostDemand>(expr=$map1T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="Repartition">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_lkqQUBfoEeePpehjS1zFvA" base_NamedElement="_QOIXoBfoEeePpehjS1zFvA" base_Action="_QOIXoBfoEeePpehjS1zFvA" numTasks="$nC1" MapType="Repartition">
     <hostDemand>(expr=$repartitionT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -188,7 +188,7 @@ source=est)}</body>
     <context>$th1</context>
     <context>$map1T</context>
     <context>$map2T</context>
-    <context>$substractT</context>
+    <context>$subtractT</context>
     <context>$nP1</context>
     <context>$nM1</context>
     <context>$nAssignedCores</context>
@@ -211,10 +211,10 @@ source=est)}</body>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
   <Spark:SparkWorkloadEvent xmi:id="_2nsW0CUKEeeGiOkBV7ej3g" base_NamedElement="_2nqhoCUKEeeGiOkBV7ej3g" sparkPopulation="$nC2" sparkExtDelay="(expr=$th2,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
+  <Spark:SparkTransformation xmi:id="_20CJsCUKEeeGiOkBV7ej3g" base_NamedElement="_2np6kCUKEeeGiOkBV7ej3g" base_Action="_2np6kCUKEeeGiOkBV7ej3g">
     <hostDemand>(expr=$map2T,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkReduce xmi:id="_oRBv8DoWEeeGuLHbg3prBg" base_NamedElement="_oQztgDoWEeeGuLHbg3prBg" base_Action="_oQztgDoWEeeGuLHbg3prBg" numTasks="$nC1" OpType="Action" ReduceType="Collect">
+  </Spark:SparkTransformation>
+  <Spark:SparkAction xmi:id="_oRBv8DoWEeeGuLHbg3prBg" base_NamedElement="_oQztgDoWEeeGuLHbg3prBg" base_Action="_oQztgDoWEeeGuLHbg3prBg" numTasks="$nC1" OpType="Action" ReduceType="Collect">
     <hostDemand>(expr=$collectT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_scheduler_througput.uml
+++ b/tests/dtsm_spark_test/standard/model_scheduler_througput.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -116,7 +116,7 @@
     <utilization>(expr=$USpark,statQ=mean,source=calc)</utilization>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_sortbykey.uml
+++ b/tests/dtsm_spark_test/standard/model_sortbykey.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -116,7 +116,7 @@
     <utilization>(expr=$USpark,statQ=mean,source=calc)</utilization>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" blockT="" numTasks="$nC1" MapType="ByKey">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" blockT="" numTasks="$nC1" MapType="ByKey">
     <hostDemand>(expr=$sortbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_sortbykey_int.uml
+++ b/tests/dtsm_spark_test/standard/model_sortbykey_int.uml
@@ -89,9 +89,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://Papyrus_PROFILES/MARTE.profile.uml#_6c2bkAPMEdyuUt-4qHuVvQ"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -116,7 +116,7 @@
     <utilization>(expr=$USpark,statQ=mean,source=calc)</utilization>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1" MapType="ByKey">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" numTasks="$nC1" MapType="ByKey">
     <hostDemand>(expr=$sortbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_spark_test/standard/model_sortbykey_w_map.uml
+++ b/tests/dtsm_spark_test/standard/model_sortbykey_w_map.uml
@@ -109,9 +109,9 @@
       <appliedProfile xmi:type="uml:Profile" href="pathmap://DICE_PROFILES/DICE.profile.uml#_lhjuYC5LEeaF_sH3mLTVKg"/>
     </profileApplication>
   </uml:Model>
-  <Spark:SparkReduce xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
+  <Spark:SparkAction xmi:id="_J2DbQBfoEeePpehjS1zFvA" base_NamedElement="_2w2sABfnEeePpehjS1zFvA" base_Action="_2w2sABfnEeePpehjS1zFvA" numTasks="$nC1" OpType="Action">
     <hostDemand>(expr=$countT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkReduce>
+  </Spark:SparkAction>
   <Spark:SparkNode xmi:id="_8W8VUBfoEeePpehjS1zFvA" base_Classifier="_UIF9sBfmEeePpehjS1zFvA" base_NamedElement="_UIF9sBfmEeePpehjS1zFvA" nCores="$nP1" Memory="$nM1">
     <utilization>(expr=$UNode,statQ=mean,source=calc)</utilization>
   </Spark:SparkNode>
@@ -137,10 +137,10 @@
     <utilization>(expr=$USpark,statQ=mean,source=calc)</utilization>
   </Spark:SparkScenario>
   <Spark:SparkWorkloadEvent xmi:id="_6RLtQBfpEeePpehjS1zFvA" base_NamedElement="_FexHYBfnEeePpehjS1zFvA" sparkPopulation="$nC1" sparkExtDelay="(expr=$th1,unit=ms,statQ=mean,source=est)"/>
-  <Spark:SparkMap xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" blockT="" numTasks="$nC1" MapType="ByKey">
+  <Spark:SparkTransformation xmi:id="_lQpE4CTdEeeGiOkBV7ej3g" base_NamedElement="_dKwi4CTdEeeGiOkBV7ej3g" base_Action="_dKwi4CTdEeeGiOkBV7ej3g" blockT="" numTasks="$nC1" MapType="ByKey">
     <hostDemand>(expr=$sortbykeyT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
-  <Spark:SparkMap xmi:id="_OvIyQEr6EeeiOeg67JALrQ" base_NamedElement="_KrgkwEr6EeeiOeg67JALrQ" base_Action="_KrgkwEr6EeeiOeg67JALrQ" numTasks="$nC1">
+  </Spark:SparkTransformation>
+  <Spark:SparkTransformation xmi:id="_OvIyQEr6EeeiOeg67JALrQ" base_NamedElement="_KrgkwEr6EeeiOeg67JALrQ" base_Action="_KrgkwEr6EeeiOeg67JALrQ" numTasks="$nC1">
     <hostDemand>(expr=$mapT,unit=ms,statQ=mean,source=est)</hostDemand>
-  </Spark:SparkMap>
+  </Spark:SparkTransformation>
 </xmi:XMI>

--- a/tests/dtsm_storm_test/model_1_spout_2_bolt_all_field.notation
+++ b/tests/dtsm_storm_test/model_1_spout_2_bolt_all_field.notation
@@ -223,7 +223,7 @@
                 <element xmi:type="uml:OpaqueAction" href="model_1_spout_2_bolt_all_field.uml#_LNmCcBXNEeaO9pVQNhbfJw"/>
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_LNy2xRXNEeaO9pVQNhbfJw" y="5"/>
               </children>
-              <styles xmi:type="notation:HintedDiagramLinkStyle" xmi:id="_LNy2wRXNEeaO9pVQNhbfJw"/>
+              <styles xmi:type="notation:HintedDiagramLinkStyle" xmi:id="_LNy2wRXNEeaO9pVQNhbfJw" diagramLink="_bBm0UFDrEee2dayUzLdxKQ"/>
               <element xmi:type="uml:OpaqueAction" href="model_1_spout_2_bolt_all_field.uml#_LNmCcBXNEeaO9pVQNhbfJw"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LNy2whXNEeaO9pVQNhbfJw" x="416" y="57" width="87"/>
             </children>
@@ -235,7 +235,7 @@
                 <element xmi:type="uml:OpaqueAction" href="model_1_spout_2_bolt_all_field.uml#_0_YMUORrEeaMmL06d2O8_g"/>
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_0_b2s-RrEeaMmL06d2O8_g" y="5"/>
               </children>
-              <styles xmi:type="notation:HintedDiagramLinkStyle" xmi:id="_0_b2tORrEeaMmL06d2O8_g" diagramLink="_359uIORrEeaMmL06d2O8_g"/>
+              <styles xmi:type="notation:HintedDiagramLinkStyle" xmi:id="_0_b2tORrEeaMmL06d2O8_g"/>
               <element xmi:type="uml:OpaqueAction" href="model_1_spout_2_bolt_all_field.uml#_0_YMUORrEeaMmL06d2O8_g"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_0_b36-RrEeaMmL06d2O8_g" x="411" y="179" width="87"/>
             </children>
@@ -514,5 +514,10 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ektgp-RsEeaMmL06d2O8_g"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ektgqORsEeaMmL06d2O8_g"/>
     </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_bBm0UFDrEee2dayUzLdxKQ" type="PapyrusUMLActivityDiagram" measurementUnit="Pixel">
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_bBm0UVDrEee2dayUzLdxKQ" name="diagram_compatibility_version" stringValue="1.2.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_bBm0UlDrEee2dayUzLdxKQ"/>
+    <element xmi:type="uml:OpaqueAction" href="model_1_spout_2_bolt_all_field.uml#_LNmCcBXNEeaO9pVQNhbfJw"/>
   </notation:Diagram>
 </xmi:XMI>

--- a/tests/dtsm_storm_test/model_1_spout_2_bolt_all_field.uml
+++ b/tests/dtsm_storm_test/model_1_spout_2_bolt_all_field.uml
@@ -77,23 +77,31 @@
   </uml:Model>
   <Storm:StormBolt xmi:id="_JiHcsDnrEeaBQNKHvmh8mQ" base_NamedElement="_LNmCcBXNEeaO9pVQNhbfJw" base_Action="_LNmCcBXNEeaO9pVQNhbfJw" parallelism="4">
     <hostDemand>(expr=5,unit=ms,statQ=mean,source=est)</hostDemand>
-    <utilization>(expr=$utilization, statQ=mean, source=calc)</utilization>
+    <utilization>(expr=$utilization1, statQ=mean, source=calc)</utilization>
   </Storm:StormBolt>
-  <Storm:StormSpout xmi:id="_UPvdADnrEeaBQNKHvmh8mQ" base_NamedElement="_CRMkoBXMEeaO9pVQNhbfJw" base_Action="_CRMkoBXMEeaO9pVQNhbfJw" targetTech="storm" parallelism="2&#xA;" avgEmitRate="&#xA;">
+  <Storm:StormSpout xmi:id="_UPvdADnrEeaBQNKHvmh8mQ" base_NamedElement="_CRMkoBXMEeaO9pVQNhbfJw" base_Action="_CRMkoBXMEeaO9pVQNhbfJw" targetTech="storm" parallelism="2" avgEmitRate="">
     <hostDemand>(expr=3.5,unit=ms,statQ=mean,source=est)</hostDemand>
+    <utilization>(expr=$utilization0, statQ=mean, source=calc)</utilization>
   </Storm:StormSpout>
   <Storm:StormSpout xmi:id="_Zb9z0DxoEea0n4gfxAdogA" base_NamedElement="_u6bKsB3CEeaAOqN-CPM2wA" base_Classifier="_u6bKsB3CEeaAOqN-CPM2wA"/>
   <Storm:StormBolt xmi:id="_cXeisDxoEea0n4gfxAdogA" base_NamedElement="_4W9h0jxnEea0n4gfxAdogA" base_Classifier="_4W9h0jxnEea0n4gfxAdogA"/>
-  <GQAM:GaExecHost xmi:id="_HVSzAD0QEea5BfFPxb1f8A" resMult="3" base_Classifier="_vdKrYB3CEeaAOqN-CPM2wA" schedPolicy="RoundRobin"/>
+  <GQAM:GaExecHost xmi:id="_HVSzAD0QEea5BfFPxb1f8A" resMult="3" base_Classifier="_vdKrYB3CEeaAOqN-CPM2wA" schedPolicy="RoundRobin">
+    <utilization>(expr=$utilization, statQ=mean, source=calc)</utilization>
+  </GQAM:GaExecHost>
   <GQAM:GaAnalysisContext xmi:id="_I0HA4H_sEea4le-Wr80mRQ" base_StructuredClassifier="_fhMfgBXCEeaO9pVQNhbfJw" base_NamedElement="_fhMfgBXCEeaO9pVQNhbfJw">
     <context>in$c1</context>
     <context>out$utilization</context>
+    <context>out$utilization1</context>
+    <context>out$utilization2</context>
+    <context>out$utilization0</context>
   </GQAM:GaAnalysisContext>
   <Storm:StormScenarioTopology xmi:id="_CuA7YGquEeaht-ghhLWJ8w" base_NamedElement="_fhMfgBXCEeaO9pVQNhbfJw" usedResources="_HVSzAD0QEea5BfFPxb1f8A" base_Behavior="_fhMfgBXCEeaO9pVQNhbfJw" base_Class="_fhMfgBXCEeaO9pVQNhbfJw"/>
-  <Storm:StormStreamStep xmi:id="_XGqN8LrbEeaDBsV1rRktkA" base_NamedElement="_QjYuMLrbEeaDBsV1rRktkA" numTuples="20" grouping="all"/>
+  <Storm:StormStreamStep xmi:id="_XGqN8LrbEeaDBsV1rRktkA" base_NamedElement="_QjYuMLrbEeaDBsV1rRktkA" numTuples="20"/>
   <Storm:StormBolt xmi:id="_0_e6AORrEeaMmL06d2O8_g" base_NamedElement="_0_YMUORrEeaMmL06d2O8_g" base_Action="_0_YMUORrEeaMmL06d2O8_g" parallelism="5">
     <hostDemand>(expr=5,unit=ms,statQ=mean,source=est)</hostDemand>
-    <utilization>(expr=$utilization, statQ=mean, source=calc)</utilization>
+    <utilization>(expr=$utilization2, statQ=mean, source=calc)</utilization>
   </Storm:StormBolt>
-  <Storm:StormStreamStep xmi:id="_ekYJcORsEeaMmL06d2O8_g" base_NamedElement="_H5bbgORsEeaMmL06d2O8_g" numTuples="6" grouping="field"/>
+  <Storm:StormStreamStep xmi:id="_ekYJcORsEeaMmL06d2O8_g" base_NamedElement="_H5bbgORsEeaMmL06d2O8_g" numTuples="6" grouping="field">
+    <probFields>0.2</probFields>
+  </Storm:StormStreamStep>
 </xmi:XMI>


### PR DESCRIPTION
This PR includes: 

- Addition of Erlang distributions in PNextensions
- Renaming arcs, transitions and colors Literals in PNextensions
- Enhancement of the Spark transformation to uses Erlang distributions instead of Exponential for low populations
- Update Spark transformation according to changes in the Spark profile done in DICE-Profiels PR #42
- Update Hadoop transformation according to changes in Literals of PNextensions
- Update of Spark examples to use the new stereotype names
- Minor bug fix in Spark transformation qvt and helpers